### PR TITLE
Fix Dialogs not working in Macos.

### DIFF
--- a/lib/native_dialog_plus.dart
+++ b/lib/native_dialog_plus.dart
@@ -23,7 +23,7 @@ class NativeDialogPlusAction {
   bool get enabled => onPressed != null;
 
   Map<dynamic, dynamic> toJson() {
-    return {"text": text, "style": style.index, "enabled": enabled};
+    return {"text": text, "style": style.index, "enabled": enabled,"destructive":style == NativeDialogPlusActionStyle.destructive};
   }
 }
 

--- a/macos/Classes/NativeDialogPlusPlugin.swift
+++ b/macos/Classes/NativeDialogPlusPlugin.swift
@@ -67,7 +67,7 @@ public class NativeDialogPlusPlugin: NSObject, FlutterPlugin {
     alert.informativeText = message ?? ""
     alert.alertStyle = alertStyle!
 
-    let buttons = args.value(forKey: "buttons") as! [NSDictionary]
+    let buttons = args.value(forKey: "actions") as! [NSDictionary]
 
     for (_, button) in buttons.enumerated() {
       let title = button.value(forKey: "text") as! String

--- a/macos/Classes/NativeDialogPlusPlugin.swift
+++ b/macos/Classes/NativeDialogPlusPlugin.swift
@@ -67,12 +67,12 @@ public class NativeDialogPlusPlugin: NSObject, FlutterPlugin {
     alert.informativeText = message ?? ""
     alert.alertStyle = alertStyle!
 
-    let buttons = args.value(forKey: "actions") as! [NSDictionary]
+    let actions = args.value(forKey: "actions") as! [NSDictionary]
 
-    for (_, button) in buttons.enumerated() {
-      let title = button.value(forKey: "text") as! String
-      let enabled = button.value(forKey: "enabled") as! Bool
-      let destructive = button.value(forKey: "destructive") as! Bool
+    for (_, action) in actions.enumerated() {
+      let title = action.value(forKey: "text") as! String
+      let enabled = action.value(forKey: "enabled") as! Bool
+      let destructive = action.value(forKey: "destructive") as! Bool
 
       let alertButton = NSButton(title: title, target: nil, action: nil)
       alertButton.isEnabled = enabled


### PR DESCRIPTION
The swift code was referencing wrong keys in the payload sent via method channel and the button json was missing "destructive" key. This PR fixes that.

I made these changes using Github UI hence I didn't change the actual variable names. 